### PR TITLE
[sync-agents] Docs: expanded SKILL.md triggers, updated README with quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,37 @@ Validate and sync agent `.md` frontmatter ↔ `agent-registry.json`. For use wit
 claude plugin install sync-agents@musabkara-claude-marketplace
 ```
 
+## Quick Start
+
+```bash
+# 1. Check — see what's out of sync
+/sync-agents
+
+# 2. Preview what --fix would change (dry-run, no writes)
+/sync-agents --diff
+
+# 3. Apply fixes
+/sync-agents --fix
+
+# 4. Show statistics
+/sync-agents --stats
+```
+
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | `/sync-agents` | Validate agents (--check mode, default) |
+| `/sync-agents --diff` | Preview what --fix would change (dry-run) |
 | `/sync-agents --fix` | Auto-fix mismatches (adds missing, removes orphaned) |
-| `/sync-agents --stats` | Show agent statistics |
+| `/sync-agents --stats` | Show agent statistics (count, active/pool, by category, by model) |
+| `/sync-agents --check --json` | Machine-readable JSON output for CI/automation |
+| `/sync-agents --path DIR` | Use alternate agents directory |
+| `/sync-agents --quiet` | Errors only, suppress info messages |
 
 ## What It Validates
 
-- Every `agents/**/*.md` has required frontmatter fields (`id`, `name`, `category`, `primary_model`, `status`)
+- Every `agents/**/*.md` has required frontmatter fields (`id`, `name`, `category`, `primary_model`, `status`, `allowed-tools`)
 - Every `id` in agent `.md` files exists in `agent-registry.json`
 - Every agent in `agent-registry.json` has a corresponding `.md` file
 - No duplicate IDs
@@ -29,9 +49,19 @@ claude plugin install sync-agents@musabkara-claude-marketplace
 
 ## Auto-Fix Behavior (`--fix`)
 
+Always run `--diff` first to preview changes.
+
 1. Adds missing agents to registry (from `.md` frontmatter)
 2. Removes orphaned registry entries (no `.md` file)
 3. Updates registry fields from `.md` frontmatter (one-way: `.md` → registry)
+
+## CI Usage
+
+```bash
+# In GitHub Actions or daily-check.sh:
+/sync-agents --check --json --quiet
+# exit 0 = clean, exit 1 = mismatches, exit 2 = error
+```
 
 ## Auto-Runs In
 
@@ -41,6 +71,11 @@ claude plugin install sync-agents@musabkara-claude-marketplace
 ## Requires
 
 [SkyWalker2506/claude-config](https://github.com/SkyWalker2506/claude-config) installed with `agents/` directory and `config/sync_agents.py`.
+
+Path is auto-detected. Checks in order:
+1. `~/Projects/claude-config/config/sync_agents.py`
+2. `~/.claude-config/config/sync_agents.py`
+3. `./config/sync_agents.py`
 
 ## Part of
 

--- a/skills/sync-agents/SKILL.md
+++ b/skills/sync-agents/SKILL.md
@@ -1,16 +1,30 @@
 ---
 name: sync-agents
-description: This skill activates when the user mentions "sync agents", "agent registry", "validate agents", "agent mismatch", "update registry", or when adding/removing agent .md files from the agents/ directory. Also runs automatically during daily-check.
-version: 1.0.0
+description: This skill activates when the user mentions "sync agents", "agent registry", "validate agents", "agent mismatch", "update registry", "fix agent", "check agents", "agent out of sync", or when adding/removing agent .md files from the agents/ directory. Also runs automatically during daily-check.
+version: 2.0.0
 ---
 
 # Agent Sync Skill
 
 Keeps `agents/*.md` frontmatter in sync with `config/agent-registry.json`.
 
+## Triggers
+
+Auto-trigger on these phrases:
+- "sync agents", "sync the agents", "sync agent registry"
+- "validate agents", "check agents", "agent check"
+- "agent registry", "update registry", "registry out of sync"
+- "agent mismatch", "agent id mismatch", "id not in registry"
+- "fix agent", "fix agents", "fix the registry"
+- "agent out of sync", "agents not in sync"
+- "add agent to registry", "remove agent from registry"
+- "what agents do I have", "show agent stats", "agent statistics"
+
+Also auto-runs during `daily-check.sh`.
+
 ## What It Validates
 
-- Every `.md` in `agents/**/*.md` has required frontmatter fields (`id`, `name`, `category`, `primary_model`, `status`)
+- Every `.md` in `agents/**/*.md` has required frontmatter fields (`id`, `name`, `category`, `primary_model`, `status`, `allowed-tools`)
 - Every `id` in agent `.md` files exists in `agent-registry.json`
 - Every agent in `agent-registry.json` has a corresponding `.md` file
 - No duplicate IDs
@@ -20,9 +34,13 @@ Keeps `agents/*.md` frontmatter in sync with `config/agent-registry.json`.
 ## Usage
 
 ```bash
-python3 config/sync_agents.py --check   # validate only
-python3 config/sync_agents.py --fix     # auto-fix mismatches
-python3 config/sync_agents.py --stats   # show statistics
+/sync-agents              # validate only (--check, default)
+/sync-agents --diff       # preview what --fix would change (dry-run)
+/sync-agents --fix        # auto-fix mismatches
+/sync-agents --stats      # show statistics breakdown
+/sync-agents --check --json  # machine-readable output for CI
+/sync-agents --path DIR   # use alternate agents directory
+/sync-agents --quiet      # errors only, suppress info
 ```
 
 ## Auto-Fix Behavior
@@ -32,9 +50,12 @@ python3 config/sync_agents.py --stats   # show statistics
 2. Remove orphaned registry entries (no .md file)
 3. Update registry fields from .md frontmatter (one-way: .md → registry)
 
+Always run `--diff` before `--fix` to preview changes.
+
 ## Integration
 
 Runs automatically in:
 - `daily-check.sh` (`--check` mode)
 - `install.sh` Phase 10 (`--check` with warning on failure)
 - Pre-commit hook (if enabled)
+- forge cycles (via `--check --json` for structured output)


### PR DESCRIPTION
## Summary
- SKILL.md v2.0.0: expanded trigger patterns, added --diff to usage, updated what-it-validates to include allowed-tools
- README: adds Quick Start section, updates Commands table with all new flags, adds CI usage example, documents path detection order

Closes #5